### PR TITLE
Update mitsurunner.yaml

### DIFF
--- a/mitsurunner.yaml
+++ b/mitsurunner.yaml
@@ -124,7 +124,7 @@ sensor:
             }
 
         // Jos haluat logata lämpötilaeroa, lisää defineen polku constants.h -tiedostoon
-        #ifdef TOPIC_TEMP_DELTA
+        #ifdef TOPIC_TEMP_DELTA_TRACES
         id(mqtt_client).publish(TOPIC_TEMP_DELTA, to_string(lampotilaero));
         #endif
 


### PR DESCRIPTION
TOPIC_TEMP_DELTA were used as name for string and as a tracing flag MACRO
Caused compilation error, which is fixed by renaming macro.