### PR TITLE
Fixed typos, language, formatting etc.

### DIFF
--- a/InstallationInstructions_FI
+++ b/InstallationInstructions_FI
@@ -18,19 +18,19 @@ Nyt tarvittava kehitysympäristö on koneellasi ja voit sulkea komentokehotteen.
 * Muokkaa tekstieditorilla yaml-tiedostoon oman kotiverkkosi WiFi-parametrit sekä haluamasi OTA password. 
 * Tarkista että lämpöantureiden ja rele-ohjauksen PIN-määrittelyt vastaavat tekemiäsi kytkentöjä. 
 
-* Liitä ESP32/ESP8266 usb-johdolla tietokoneeseesi
-* Avaa komentokehote/terminaali, siirry "Runner"-hakemistoon ja anna komento `esphome hw_check.yaml run`
+* Liitä ESP32/ESP8266 USB-johdolla tietokoneeseesi
+* Avaa komentokehote/terminaali, siirry "Runner"-hakemistoon ja anna komento `esphome run hw_check.yaml`
 * Jos asennus onnistuu, ohjelma kysyy lataustapaa (USB vai OTA). Valitse `USB`.
 ==> Ohjelma siirtyy USB:n kautta laitteelle
 
-* Jos siirtäminen ei onnistu tarkista että koneellesi on asennettu USB-ohjain esim. CHG340G tms.
+* Jos siirtäminen ei onnistu, tarkista että koneellesi on asennettu USB-ohjain esim. CHG340G tms.
 
 Tarkasta:
 * Rele naksuu (0.5 sek ON 5 sek välein)
-* Ruudulle tulostuu logi josta näkyy
+* Ruudulle tulostuu logi, josta näkyy:
 ** Laite on kytkeytynyt kotiverkkoosi
 ** DS18B20 antureiden ID-tunnukset - kirjaa ylös, tarvitset näitä myöhemmin - ja mitatut lämpötilat
-** Testaa myös OTA-lataus antamalla `esphome mitsurunner.yaml run` uudelleen, mutta valitse nyt lataustavaksi `OTA`
+** Testaa myös OTA-lataus antamalla `esphome run mitsurunner.yaml` uudelleen, mutta valitse nyt lataustavaksi `OTA`
 
 ## Mitsurunner-ohjelmisto
 
@@ -46,7 +46,7 @@ Näet kotiverkkosi käyttämän Gateway-ip:n esim. Windowsin komentokehotteella 
 ** Määritä DS18B20-antureiden ID:t - kirjasit nämä ylös hw_check-ohjelmaa käyttäessäsi
 ** Tarkista/korjaa tarvittaessa lämpöantureiden ja rele-ohjauksen PIN-määrittelyt vastaamaan tekemiäsi kytkentöjä
 
-* Käännä ja lähetä ohjelma laitteeseen komennolla `esphome mitsurunner.yaml run`
+* Käännä ja lähetä ohjelma laitteeseen komennolla `esphome run mitsurunner.yaml`
 
 ### Tarkista:
 Ruudulle tulostuu logi josta näkyy
@@ -76,7 +76,7 @@ Muokkaa platform.yaml-tiedostoon:
 `client_id: p5NVA6zTBfP***CQMvoR7A` <== kopioi IoT-guru "wemos" DEVICE/Device Details -sivulta löytyvä `DEVICE SHORT IDENTIFIER`
 `password: h06UcwI2-dAp***4ZvVEVA` <== kopio IoT_GURU "wemos" DEVICE/Device Details -sivulta löytyvä `DEVICE KEY`
 
-Kopio valmiit mqtt-stringit IoT-guru-sivuilta
+Kopioi valmiit mqtt-stringit IoT-guru-sivuilta
 
 # MQTT topics. These are inside single quotes
 topic_heatexchanger: 'kopio IoT-guru "mitsu"NODE-"kenno"-FIELD/Help-välilehdeltä `GENERIC MQTT TOPIC string` tähän

--- a/constants.h
+++ b/constants.h
@@ -1,26 +1,24 @@
-/*
-# Copyright (c) 2021 Veli Matti Lastumäki (Velsku at lampopumput.info),
-#                    Joonas Ihonen (puu at lampopumput.info)
-#
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/* Copyright (c) 2021 Veli Matti Lastumäki (Velsku at lampopumput.info),
+ *                    Joonas Ihonen (puu at lampopumput.info)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #ifndef __CONSTANTS_H__
 #define __CONSTANTS_H__
@@ -44,22 +42,22 @@ const float HEAT_EXCHANGER_MAX_TEMPERATURE = 50.0;
  * forced defrosting will be started. */
 #define MAX_HEATING_TIME                150 /* minutes */
 
-/* The minumum time between defrosting operations. */
+/* The minimum time between defrosting operations. */
 #define MIN_HEATING_TIME                50  /* minutes */
 
 /* The time that the defrost hack relays is off after defrosting is started. */
 #define RELAY_OFF_TIME                  30  /* minutes */
 
 /* If defrosting is not started during this time after switching the relay off,
-   state will be set back to IDLE inetead of DEFROSTING STARTED */
+   state will be set back to IDLE instead of DEFROSTING STARTED */
 #define DEFROST_TIMEOUT                 10  /* minutes */
 
 /* Delay at the reset before allowing state machine to step to next states 
- * Gives time for the sensors to be reads*/
+ * Gives time for the sensors to be read*/
 #define RESET_SENSOR_DELAY				25  /* seconds */
  
-/* Delay at the device bootup before starting the state machine to give 
- * time for the sensors to be read, system to connect to wifi and system to connect to MQTT broker */
+/* Delay at the device bootup before starting the state machine to give time for the
+ * sensors to be read, system to connect to wifi and system to connect to MQTT broker */
 #define INITIALIZE_DELAY                60  /* seconds*/
 
 

--- a/hw_check/hw_check.yaml
+++ b/hw_check/hw_check.yaml
@@ -3,7 +3,7 @@
 # Switches relay: 1sec on, 4sec off
 
 esphome:
-  name: mitsurunner-hw-check  
+  name: mitsurunner-hw-check
 # HW-platform
   platform: esp8266
   board: d1_mini
@@ -15,7 +15,7 @@ wifi:
 
   manual_ip:
 # Mitsurunner's IP address
-    static_ip: 192.168.1.100 
+    static_ip: 192.168.1.100
     subnet: 255.255.255.0
     gateway: 192.168.1.1
 

--- a/mitsurunner.yaml
+++ b/mitsurunner.yaml
@@ -265,8 +265,7 @@ sensor:
                 // or the upper temperature limit is exceeded, start defrosting directly.
                 else if (id(G_max_heating_time_passed)) {
                     id(enter_StartDefrosting).execute();
-                } 
-
+                }
                 break;
 
             // Should never end up in here

--- a/platform.yaml
+++ b/platform.yaml
@@ -20,7 +20,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-SETTINGS: Your wifi details 
+# SETTINGS: Your wifi details
 wifi:
   ssid: "xxxxx"
   password: "xxxxxxxx"

--- a/state.h
+++ b/state.h
@@ -1,26 +1,24 @@
-/*
-# Copyright (c) 2021 Veli Matti Lastumäki (Velsku at lampopumput.info),
-#                    Joonas Ihonen (puu at lampopumput.info)
-#
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/* Copyright (c) 2021 Veli Matti Lastumäki (Velsku at lampopumput.info),
+ *                    Joonas Ihonen (puu at lampopumput.info)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #ifndef __STATE_H__
 #define __STATE_H__


### PR DESCRIPTION
- Previous commit removed a comment "#" before SETTINGS in platform.yaml that made it not to compile, fixed
- ESPhome says that "run" after yaml file is deprecated format, so I changed it before in the instructions
- Changed hw_check.yaml line ending from CRLF to LF as in other files
- Typo and language fixes
- Formatting polishing etc. 