### PR TITLE
Separate Dallas configs

### DIFF
--- a/dallas_basic.yaml
+++ b/dallas_basic.yaml
@@ -1,0 +1,66 @@
+# Temperature sensor (Dallas DS18B20) and its update/measurement interval
+dallas:
+  - pin: $dallas_pin
+    update_interval: 5s
+    id: dallas1
+
+
+# Temperature sensor (Dallas DS18B20) details. 
+# You need to check temperature sensors IDs by starting this software and checking IDs from log printing to terminal. 
+# Copy IDs from terminal log to platform.yaml file and heat one sensor. Then check which sensor it was and use it for the corresponding topic
+sensor:
+  - platform: dallas
+    address: $dallas_address_heat_exchanger_temp # Remember to define this on platform.yaml
+ #   index: 0    #Use index instead of address only for testing
+    name: "Temperature - heat exchanger"
+    id: heat_exchanger_temp
+    accuracy_decimals: 1
+    state_topic: $topic_heatexchanger
+    filters:
+      - filter_out: nan
+      - filter_out: 85.0
+      - exponential_moving_average:
+          # Be careful when tweaking this filter, too small alpha may delay defrosting too much
+          alpha: 0.05
+          send_every: 6 #30s
+    on_raw_value:
+      then:
+        lambda: !lambda |-
+            if ((isnan(x)) || (x > 84.0)) {
+                if ((id(heat_exchanger_temp_errors) += 1) == 1000) id(heat_exchanger_temp_errors) = 10;
+            }
+
+  - platform: dallas
+    address: $dallas_address_outdoor_temp # Remember to define this on platform.yaml
+ #   index: 1   #Use index instead of address only for testing
+    name: "Temperature - outdoor"
+    id: outdoor_temp
+    accuracy_decimals: 1
+    state_topic: $topic_outdoor
+    filters:
+      - filter_out: nan
+      - filter_out: 85.0
+      - exponential_moving_average:
+          alpha: 0.01
+          send_every: 6 #30s
+          send_first_at: 2 #10s
+    on_raw_value:
+      then:
+        lambda: !lambda |-
+            // Calculate exponential moving average for outdoor temperature
+            // Alpha is adjustable, similar to one in the built-in exponential_moving_average filter
+            static const float alpha = 0.1;
+            static bool first_time = true;
+
+            if ((isnan(x)) || (x > 84.0))  { //Check if non-valid Dallas value
+                if ((id(outdoor_temp_errors) += 1) == 1000) id(outdoor_temp_errors) = 10;
+            }
+            // Valid Dallas value received, do not use filter until first value received
+            else if(first_time) {
+                id(G_outdoor_temp_filtered) = x;
+                first_time = false;
+            }
+            else {
+                id(G_outdoor_temp_filtered) = id(G_outdoor_temp_filtered) * (1.0 - alpha) + x * alpha;
+            }
+

--- a/dallas_hub.yaml
+++ b/dallas_hub.yaml
@@ -1,0 +1,92 @@
+# To minimize mitsurunner restarts, a separate hub is created for each Dallas sensor. 
+# The system is made for two Dallas sensors.
+# Each Dallas sensor is read every 5000ms, interval between reading Dallas_A and Dallas_B is 2500ms.
+
+# Temperature sensor (Dallas DS18B20) and its update/measurement interval
+dallas:
+  - id: "DS18B20_a"
+    pin:
+      number: $dallas_pin
+      allow_other_uses: true
+    update_interval: never
+  - id: "DS18B20_b"
+    pin:
+      number: $dallas_pin
+      allow_other_uses: true
+    update_interval: never
+
+# to avoid 1w-sequence overlapping synchronize DS18B20-readings (12bit conversion takes 750ms)
+interval:
+  - interval: 2500ms
+    then:
+      - lambda: !lambda |-
+          static int n = 0;
+          if (n == 0) {
+            id(DS18B20_a).update();   //read outdoor unit heat exchanger temperature
+            n = 1;
+            }
+          else {
+            id(DS18B20_b).update();  //outdoor temperature
+            n = 0;
+            }
+
+
+# Temperature sensor (Dallas DS18B20) details. 
+# You need to check temperature sensors IDs by starting this software and checking IDs from log printing to terminal. 
+# Copy IDs from terminal log to platform.yaml file and heat one sensor. Then check which sensor it was and use it for the corresponding topic
+sensor:
+  - platform: dallas
+    dallas_id: DS18B20_a
+    address: $dallas_address_heat_exchanger_temp # Remember to define this on platform.yaml
+    name: "Temperature - heat exchanger"
+    id: heat_exchanger_temp
+    accuracy_decimals: 1
+    state_topic: $topic_heatexchanger
+    filters:
+      - filter_out: nan
+      - filter_out: 85.0
+      - exponential_moving_average:
+          # Be careful when tweaking this filter, too small alpha may delay defrosting too much
+          alpha: 0.05
+          send_every: 6 #30s
+    on_raw_value:
+      then:
+        lambda: !lambda |-
+            if ((isnan(x)) || (x > 84.0)) {
+                if ((id(heat_exchanger_temp_errors) += 1) == 1000) id(heat_exchanger_temp_errors) = 10;
+            }
+
+  - platform: dallas
+    dallas_id: DS18B20_b
+    address: $dallas_address_outdoor_temp # Remember to define this on platform.yaml
+    name: "Temperature - outdoor"
+    id: outdoor_temp
+    accuracy_decimals: 1
+    state_topic: $topic_outdoor
+    filters:
+      - filter_out: nan
+      - filter_out: 85.0
+      - exponential_moving_average:
+          alpha: 0.01
+          send_every: 6 #30s
+          send_first_at: 2 #10s
+    on_raw_value:
+      then:
+        lambda: !lambda |-
+            // Calculate exponential moving average for outdoor temperature
+            // Alpha is adjustable, similar to one in the built-in exponential_moving_average filter
+            static const float alpha = 0.1;
+            static bool first_time = true;
+
+            if ((isnan(x)) || (x > 84.0))  { //Check if non-valid Dallas value
+                if ((id(outdoor_temp_errors) += 1) == 1000) id(outdoor_temp_errors) = 10;
+            }
+            // Valid Dallas value received, do not use filter until first value received
+            else if(first_time) {
+                id(G_outdoor_temp_filtered) = x;
+                first_time = false;
+            }
+            else {
+                id(G_outdoor_temp_filtered) = id(G_outdoor_temp_filtered) * (1.0 - alpha) + x * alpha;
+            }
+

--- a/mitsurunner.yaml
+++ b/mitsurunner.yaml
@@ -26,7 +26,12 @@
 
 # Select used platform (Wemos or Sonoff TH Elite)
 <<: !include platform_wemos.yaml
-#<<: !include platform_elite.yaml
+# <<: !include platform_elite.yaml
+
+# Select configuration of Dallas sensors
+packages:
+  device_base: !include dallas_basic.yaml # Basic configuration
+#  device_base: !include dallas_hub.yaml # Separate Dallas-hubs for minimize restarts
 
 # initialize and define Mitsurunner
 esphome:
@@ -110,12 +115,6 @@ globals:
     initial_value: $topic_outdoor_raw
 
 
-# Temperature sensor (Dallas DS18B20) and its update/measurement interval
-dallas:
-  - pin: $dallas_pin
-    update_interval: 5s
-    id: dallas1
-
 # switch component to control defrost prevention relay
 # if switch on --> Relay actively driven
 # if switch off --> Relay in default state
@@ -170,84 +169,14 @@ switch:
       then:
           lambda: !lambda "id(G_manual_defrosting) = false;"
 
-# Temperature sensor (Dallas DS18B20) details. 
-# You need to check temperature sensors IDs by starting this software and checking IDs from log printing to terminal. 
-# Copy IDs from terminal log to platform.yaml file and heat one sensor. Then check which sensor it was and use it for the corresponding topic
+
 sensor:
-  - platform: dallas
-    address: $dallas_address_heat_exchanger_temp # Remember to define this on platform.yaml
- #   index: 0    #Use index instead of address only for testing
-    name: "Temperature - heat exchanger"
-    id: heat_exchanger_temp
-    accuracy_decimals: 1
-    state_topic: $topic_heatexchanger
-    filters:
-      - filter_out: nan
-      - filter_out: 85.0
-      - exponential_moving_average:
-          # Be careful when tweaking this filter, too small alpha may delay defrosting too much
-          alpha: 0.05
-          send_every: 6 #30s
-    on_raw_value:
-      then:
-        lambda: !lambda |-
-            if ((isnan(x)) || (x > 84.0)) {
-                if ((id(heat_exchanger_temp_errors) += 1) == 1000) id(heat_exchanger_temp_errors) = 10;
-            }
-
-  - platform: dallas
-    address: $dallas_address_outdoor_temp # Remember to define this on platform.yaml
- #   index: 1   #Use index instead of address only for testing
-    name: "Temperature - outdoor"
-    id: outdoor_temp
-    accuracy_decimals: 1
-    state_topic: $topic_outdoor
-    filters:
-      - filter_out: nan
-      - filter_out: 85.0
-      - exponential_moving_average:
-          alpha: 0.01
-          send_every: 6 #30s
-          send_first_at: 2 #10s
-    on_raw_value:
-      then:
-        lambda: !lambda |-
-            // Calculate exponential moving average for outdoor temperature
-            // Alpha is adjustable, similar to one in the built-in exponential_moving_average filter
-            static const float alpha = 0.1;
-            static bool first_time = true;
-
-            if ((isnan(x)) || (x > 84.0))  { //Check if non-valid Dallas value
-                if ((id(outdoor_temp_errors) += 1) == 1000) id(outdoor_temp_errors) = 10;
-            }
-            // Valid Dallas value received, do not use filter until first value received
-            else if(first_time) {
-                id(G_outdoor_temp_filtered) = x;
-                first_time = false;
-            }
-            else {
-                id(G_outdoor_temp_filtered) = id(G_outdoor_temp_filtered) * (1.0 - alpha) + x * alpha;
-            }
-
   # To show state on the web server
   - platform: template
     name: "State"
     id: state_template
     lambda: "return id(G_state);"
 
-# Additional sensors can be added by defining new sensors - uncomment example below:
-# e.g. for having another sensors to measure outdoor temperature from different place. (not used by logic)
-  # - platform: dallas
-  #   address: $dallas_address_test
-  #   name: "test_temperature"
-  #   id: test_temperature
-  #   accuracy_decimals: 1
-  #   state_topic: $topic_test
-  #   filters:
-  #     - filter_out: nan
-  #     - exponential_moving_average:
-  #         alpha: 0.01
-  #         send_every: 2
 
  # RSSI monitoring, reports the WiFi signal strength in dBm
   - platform: wifi_signal

--- a/platform_elite.yaml.orig
+++ b/platform_elite.yaml.orig
@@ -1,0 +1,136 @@
+# Copyright (c) 2021 Veli Matti Lastumäki (Velsku at lampopumput.info),
+#                    Joonas Ihonen (puu at lampopumput.info),
+#                    Ilkka Roivainen (iro at lampopumput.info)
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Enable logging to terminal. You can read log messages over wifi
+logger:
+
+substitutions:
+# Define these values according to your hardware see: https://esphome.io
+  platform_type: 'esp32'
+  board_type:    'nodemcu-32s'
+
+# Addresses for your Dallas DS18B20 temperature sensors - you need to update these
+  dallas_address_heat_exchanger_temp: '0x8501191438ccd428'
+  dallas_address_outdoor_temp:        '0x93000802B67D1E10'
+
+# MQTT topics. These are inside single quotes:
+# If you use IoT Guru: Replace with your own values: uuu = user_id, ccc = client_id, nnn = node_short_identifier.
+# In IoT Guru see Field > Help and copy/paste the line under 'GENERIC MQTT TOPIC'
+# It should look like: "pub/qwertyuiop/asdfghjkl/zxcvbnm/temperature_delta"
+  topic_heatexchanger:                  'pub/uuu/ccc/nnn/heatex_temperature'
+  topic_outdoor:                        'pub/uuu/ccc/nnn/outdoor_temperature'
+  topic_delta:                          'pub/uuu/ccc/nnn/temperature_delta'
+  topic_rssi:                           'pub/uuu/ccc/nnn/rssi'
+  topic_outdoor_errors:                 'pub/uuu/ccc/nnn/error_outdoor'
+  topic_exchanger_errors:               'pub/uuu/ccc/nnn/error_heatex'
+  topic_delta_temperature_latest_min:   'pub/uuu/ccc/nnn/temperature_delta_latest_min'
+  topic_uptime:                         'pub/uuu/ccc/nnn/uptime'
+
+# MQTT topics. Notice that these are inside both single and double quotes:
+  topic_outdoor_raw:                    '"pub/uuu/ccc/nnn/outdoor_raw_temperature"'
+  topic_state:                          '"pub/uuu/ccc/nnn/state"'
+  topic_excess_timer_state:             '"pub/uuu/ccc/nnn/excess_timer_state"'
+  topic_min_heating_timer_state:        '"pub/uuu/ccc/nnn/min_heating_timer_state"'
+  topic_defrosting_timer_state:         '"pub/uuu/ccc/nnn/defrosting_timer_state"'
+  topic_start_defrosting_timer_state:   '"pub/uuu/ccc/nnn/start_defrosting_timer_state"'
+  topic_force_defrost_timer_state:      '"pub/uuu/ccc/nnn/force_defrost_timer_state"'
+  topic_reset_timer_state:              '"pub/uuu/ccc/nnn/reset_timer_state"'
+  topic_error:                          '"pub/uuu/ccc/nnn/error"'
+
+# IO-pins:
+  dallas_pin: 'GPIO25' # Pin for DS18B20 1-wire temperature sensors. Set to the pin number you are using.
+  relay_pin: 'GPIO4' # Pin for controlling relay
+  dallas_power_pin: 'GPIO27'
+
+
+#############################################################################
+#########################Sonoff Th Elite display#############################
+###            two LCD screens alternate every 5 seconds                  ###
+#############################################################################
+###   heat_exchanger_temp  ###########  Wifi-signal        ##################
+###   outdoor_temp         ###########  Dallas error count ##################
+#############################################################################
+### RED LED = POWER #### GREEN LED = Defrost prevention control activated ###
+#############################################################################
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    inverted: true
+    id: red_led
+
+  - platform: gpio
+    pin: GPIO13
+    inverted: true
+    id: green_led
+
+<<<<<<< HEAD
+#  - platform: gpio
+#    pin: GPIO15
+#    inverted: true
+#    id: yellow_led
+=======
+  - platform: gpio
+    pin: GPIO15
+    inverted: true
+    id: yellow_led
+>>>>>>> Add Sonoff Elite configuration
+
+
+display:
+  platform: tm1621
+  id: tm1621_display
+  update_interval: 5s
+  cs_pin: GPIO17
+<<<<<<< HEAD
+  data_pin:
+    number: GPIO5
+    ignore_strapping_warning: true
+=======
+  data_pin: GPIO5
+>>>>>>> Add Sonoff Elite configuration
+  read_pin: GPIO23
+  write_pin: GPIO18
+  lambda: |-
+    static int n = 0;
+    id(red_led).turn_on();                                //Keep POWER-led ON
+
+    if (id(gpio_relay).state) id(green_led).turn_on();    //Green LED ON if defrost_prevention_Relay is ON
+    else id(green_led).turn_off();
+
+    if (n == 0) {
+       n = 1;
+       it.printf(0, "%.1f", id(heat_exchanger_temp).state);
+       it.display_celsius(true);
+       it.printf(1, "%.1f", id(outdoor_temp).state);
+       it.display_humidity(false);
+       }
+     else {
+       n = 0;
+       it.printf(0, "%.1f", id(wifi_signal_dbm).state);
+       it.display_celsius(false);
+       it.printf(1,"%.1i", id(outdoor_temp_errors)+ id(heat_exchanger_temp_errors));
+       it.display_humidity(false);
+       }
+
+

--- a/platform_elite_BACKUP_2682.yaml
+++ b/platform_elite_BACKUP_2682.yaml
@@ -1,0 +1,136 @@
+# Copyright (c) 2021 Veli Matti Lastumäki (Velsku at lampopumput.info),
+#                    Joonas Ihonen (puu at lampopumput.info),
+#                    Ilkka Roivainen (iro at lampopumput.info)
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Enable logging to terminal. You can read log messages over wifi
+logger:
+
+substitutions:
+# Define these values according to your hardware see: https://esphome.io
+  platform_type: 'esp32'
+  board_type:    'nodemcu-32s'
+
+# Addresses for your Dallas DS18B20 temperature sensors - you need to update these
+  dallas_address_heat_exchanger_temp: '0x8501191438ccd428'
+  dallas_address_outdoor_temp:        '0x93000802B67D1E10'
+
+# MQTT topics. These are inside single quotes:
+# If you use IoT Guru: Replace with your own values: uuu = user_id, ccc = client_id, nnn = node_short_identifier.
+# In IoT Guru see Field > Help and copy/paste the line under 'GENERIC MQTT TOPIC'
+# It should look like: "pub/qwertyuiop/asdfghjkl/zxcvbnm/temperature_delta"
+  topic_heatexchanger:                  'pub/uuu/ccc/nnn/heatex_temperature'
+  topic_outdoor:                        'pub/uuu/ccc/nnn/outdoor_temperature'
+  topic_delta:                          'pub/uuu/ccc/nnn/temperature_delta'
+  topic_rssi:                           'pub/uuu/ccc/nnn/rssi'
+  topic_outdoor_errors:                 'pub/uuu/ccc/nnn/error_outdoor'
+  topic_exchanger_errors:               'pub/uuu/ccc/nnn/error_heatex'
+  topic_delta_temperature_latest_min:   'pub/uuu/ccc/nnn/temperature_delta_latest_min'
+  topic_uptime:                         'pub/uuu/ccc/nnn/uptime'
+
+# MQTT topics. Notice that these are inside both single and double quotes:
+  topic_outdoor_raw:                    '"pub/uuu/ccc/nnn/outdoor_raw_temperature"'
+  topic_state:                          '"pub/uuu/ccc/nnn/state"'
+  topic_excess_timer_state:             '"pub/uuu/ccc/nnn/excess_timer_state"'
+  topic_min_heating_timer_state:        '"pub/uuu/ccc/nnn/min_heating_timer_state"'
+  topic_defrosting_timer_state:         '"pub/uuu/ccc/nnn/defrosting_timer_state"'
+  topic_start_defrosting_timer_state:   '"pub/uuu/ccc/nnn/start_defrosting_timer_state"'
+  topic_force_defrost_timer_state:      '"pub/uuu/ccc/nnn/force_defrost_timer_state"'
+  topic_reset_timer_state:              '"pub/uuu/ccc/nnn/reset_timer_state"'
+  topic_error:                          '"pub/uuu/ccc/nnn/error"'
+
+# IO-pins:
+  dallas_pin: 'GPIO25' # Pin for DS18B20 1-wire temperature sensors. Set to the pin number you are using.
+  relay_pin: 'GPIO4' # Pin for controlling relay
+  dallas_power_pin: 'GPIO27'
+
+
+#############################################################################
+#########################Sonoff Th Elite display#############################
+###            two LCD screens alternate every 5 seconds                  ###
+#############################################################################
+###   heat_exchanger_temp  ###########  Wifi-signal        ##################
+###   outdoor_temp         ###########  Dallas error count ##################
+#############################################################################
+### RED LED = POWER #### GREEN LED = Defrost prevention control activated ###
+#############################################################################
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    inverted: true
+    id: red_led
+
+  - platform: gpio
+    pin: GPIO13
+    inverted: true
+    id: green_led
+
+<<<<<<< HEAD
+#  - platform: gpio
+#    pin: GPIO15
+#    inverted: true
+#    id: yellow_led
+=======
+  - platform: gpio
+    pin: GPIO15
+    inverted: true
+    id: yellow_led
+>>>>>>> Add Sonoff Elite configuration
+
+
+display:
+  platform: tm1621
+  id: tm1621_display
+  update_interval: 5s
+  cs_pin: GPIO17
+<<<<<<< HEAD
+  data_pin:
+    number: GPIO5
+    ignore_strapping_warning: true
+=======
+  data_pin: GPIO5
+>>>>>>> Add Sonoff Elite configuration
+  read_pin: GPIO23
+  write_pin: GPIO18
+  lambda: |-
+    static int n = 0;
+    id(red_led).turn_on();                                //Keep POWER-led ON
+
+    if (id(gpio_relay).state) id(green_led).turn_on();    //Green LED ON if defrost_prevention_Relay is ON
+    else id(green_led).turn_off();
+
+    if (n == 0) {
+       n = 1;
+       it.printf(0, "%.1f", id(heat_exchanger_temp).state);
+       it.display_celsius(true);
+       it.printf(1, "%.1f", id(outdoor_temp).state);
+       it.display_humidity(false);
+       }
+     else {
+       n = 0;
+       it.printf(0, "%.1f", id(wifi_signal_dbm).state);
+       it.display_celsius(false);
+       it.printf(1,"%.1i", id(outdoor_temp_errors)+ id(heat_exchanger_temp_errors));
+       it.display_humidity(false);
+       }
+
+

--- a/platform_elite_LOCAL_2682.yaml
+++ b/platform_elite_LOCAL_2682.yaml
@@ -1,0 +1,125 @@
+# Copyright (c) 2021 Veli Matti Lastumäki (Velsku at lampopumput.info),
+#                    Joonas Ihonen (puu at lampopumput.info),
+#                    Ilkka Roivainen (iro at lampopumput.info)
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Enable logging to terminal. You can read log messages over wifi
+logger:
+
+substitutions:
+# Define these values according to your hardware see: https://esphome.io
+  platform_type: 'esp32'
+  board_type:    'nodemcu-32s'
+
+# Addresses for your Dallas DS18B20 temperature sensors - you need to update these
+  dallas_address_heat_exchanger_temp: '0x8501191438ccd428'
+  dallas_address_outdoor_temp:        '0x93000802B67D1E10'
+
+# MQTT topics. These are inside single quotes:
+# If you use IoT Guru: Replace with your own values: uuu = user_id, ccc = client_id, nnn = node_short_identifier.
+# In IoT Guru see Field > Help and copy/paste the line under 'GENERIC MQTT TOPIC'
+# It should look like: "pub/qwertyuiop/asdfghjkl/zxcvbnm/temperature_delta"
+  topic_heatexchanger:                  'pub/uuu/ccc/nnn/heatex_temperature'
+  topic_outdoor:                        'pub/uuu/ccc/nnn/outdoor_temperature'
+  topic_delta:                          'pub/uuu/ccc/nnn/temperature_delta'
+  topic_rssi:                           'pub/uuu/ccc/nnn/rssi'
+  topic_outdoor_errors:                 'pub/uuu/ccc/nnn/error_outdoor'
+  topic_exchanger_errors:               'pub/uuu/ccc/nnn/error_heatex'
+  topic_delta_temperature_latest_min:   'pub/uuu/ccc/nnn/temperature_delta_latest_min'
+  topic_uptime:                         'pub/uuu/ccc/nnn/uptime'
+
+# MQTT topics. Notice that these are inside both single and double quotes:
+  topic_outdoor_raw:                    '"pub/uuu/ccc/nnn/outdoor_raw_temperature"'
+  topic_state:                          '"pub/uuu/ccc/nnn/state"'
+  topic_excess_timer_state:             '"pub/uuu/ccc/nnn/excess_timer_state"'
+  topic_min_heating_timer_state:        '"pub/uuu/ccc/nnn/min_heating_timer_state"'
+  topic_defrosting_timer_state:         '"pub/uuu/ccc/nnn/defrosting_timer_state"'
+  topic_start_defrosting_timer_state:   '"pub/uuu/ccc/nnn/start_defrosting_timer_state"'
+  topic_force_defrost_timer_state:      '"pub/uuu/ccc/nnn/force_defrost_timer_state"'
+  topic_reset_timer_state:              '"pub/uuu/ccc/nnn/reset_timer_state"'
+  topic_error:                          '"pub/uuu/ccc/nnn/error"'
+
+# IO-pins:
+  dallas_pin: 'GPIO25' # Pin for DS18B20 1-wire temperature sensors. Set to the pin number you are using.
+  relay_pin: 'GPIO4' # Pin for controlling relay
+  dallas_power_pin: 'GPIO27'
+
+
+#############################################################################
+#########################Sonoff Th Elite display#############################
+###            two LCD screens alternate every 5 seconds                  ###
+#############################################################################
+###   heat_exchanger_temp  ###########  Wifi-signal        ##################
+###   outdoor_temp         ###########  Dallas error count ##################
+#############################################################################
+### RED LED = POWER #### GREEN LED = Defrost prevention control activated ###
+#############################################################################
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    inverted: true
+    id: red_led
+
+  - platform: gpio
+    pin: GPIO13
+    inverted: true
+    id: green_led
+
+#  - platform: gpio
+#    pin: GPIO15
+#    inverted: true
+#    id: yellow_led
+
+
+display:
+  platform: tm1621
+  id: tm1621_display
+  update_interval: 5s
+  cs_pin: GPIO17
+  data_pin:
+    number: GPIO5
+    ignore_strapping_warning: true
+  read_pin: GPIO23
+  write_pin: GPIO18
+  lambda: |-
+    static int n = 0;
+    id(red_led).turn_on();                                //Keep POWER-led ON
+
+    if (id(gpio_relay).state) id(green_led).turn_on();    //Green LED ON if defrost_prevention_Relay is ON
+    else id(green_led).turn_off();
+
+    if (n == 0) {
+       n = 1;
+       it.printf(0, "%.1f", id(heat_exchanger_temp).state);
+       it.display_celsius(true);
+       it.printf(1, "%.1f", id(outdoor_temp).state);
+       it.display_humidity(false);
+       }
+     else {
+       n = 0;
+       it.printf(0, "%.1f", id(wifi_signal_dbm).state);
+       it.display_celsius(false);
+       it.printf(1,"%.1i", id(outdoor_temp_errors)+ id(heat_exchanger_temp_errors));
+       it.display_humidity(false);
+       }
+
+

--- a/platform_elite_REMOTE_2682.yaml
+++ b/platform_elite_REMOTE_2682.yaml
@@ -1,0 +1,123 @@
+# Copyright (c) 2021 Veli Matti Lastumäki (Velsku at lampopumput.info),
+#                    Joonas Ihonen (puu at lampopumput.info),
+#                    Ilkka Roivainen (iro at lampopumput.info)
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Enable logging to terminal. You can read log messages over wifi
+logger:
+
+substitutions:
+# Define these values according to your hardware see: https://esphome.io
+  platform_type: 'esp32'
+  board_type:    'nodemcu-32s'
+
+# Addresses for your Dallas DS18B20 temperature sensors - you need to update these
+  dallas_address_heat_exchanger_temp: '0x8501191438ccd428'
+  dallas_address_outdoor_temp:        '0x93000802B67D1E10'
+
+# MQTT topics. These are inside single quotes:
+# If you use IoT Guru: Replace with your own values: uuu = user_id, ccc = client_id, nnn = node_short_identifier.
+# In IoT Guru see Field > Help and copy/paste the line under 'GENERIC MQTT TOPIC'
+# It should look like: "pub/qwertyuiop/asdfghjkl/zxcvbnm/temperature_delta"
+  topic_heatexchanger:                  'pub/uuu/ccc/nnn/heatex_temperature'
+  topic_outdoor:                        'pub/uuu/ccc/nnn/outdoor_temperature'
+  topic_delta:                          'pub/uuu/ccc/nnn/temperature_delta'
+  topic_rssi:                           'pub/uuu/ccc/nnn/rssi'
+  topic_outdoor_errors:                 'pub/uuu/ccc/nnn/error_outdoor'
+  topic_exchanger_errors:               'pub/uuu/ccc/nnn/error_heatex'
+  topic_delta_temperature_latest_min:   'pub/uuu/ccc/nnn/temperature_delta_latest_min'
+  topic_uptime:                         'pub/uuu/ccc/nnn/uptime'
+
+# MQTT topics. Notice that these are inside both single and double quotes:
+  topic_outdoor_raw:                    '"pub/uuu/ccc/nnn/outdoor_raw_temperature"'
+  topic_state:                          '"pub/uuu/ccc/nnn/state"'
+  topic_excess_timer_state:             '"pub/uuu/ccc/nnn/excess_timer_state"'
+  topic_min_heating_timer_state:        '"pub/uuu/ccc/nnn/min_heating_timer_state"'
+  topic_defrosting_timer_state:         '"pub/uuu/ccc/nnn/defrosting_timer_state"'
+  topic_start_defrosting_timer_state:   '"pub/uuu/ccc/nnn/start_defrosting_timer_state"'
+  topic_force_defrost_timer_state:      '"pub/uuu/ccc/nnn/force_defrost_timer_state"'
+  topic_reset_timer_state:              '"pub/uuu/ccc/nnn/reset_timer_state"'
+  topic_error:                          '"pub/uuu/ccc/nnn/error"'
+
+# IO-pins:
+  dallas_pin: 'GPIO25' # Pin for DS18B20 1-wire temperature sensors. Set to the pin number you are using.
+  relay_pin: 'GPIO4' # Pin for controlling relay
+  dallas_power_pin: 'GPIO27'
+
+
+#############################################################################
+#########################Sonoff Th Elite display#############################
+###            two LCD screens alternate every 5 seconds                  ###
+#############################################################################
+###   heat_exchanger_temp  ###########  Wifi-signal        ##################
+###   outdoor_temp         ###########  Dallas error count ##################
+#############################################################################
+### RED LED = POWER #### GREEN LED = Defrost prevention control activated ###
+#############################################################################
+
+output:
+  - platform: gpio
+    pin: GPIO16
+    inverted: true
+    id: red_led
+
+  - platform: gpio
+    pin: GPIO13
+    inverted: true
+    id: green_led
+
+  - platform: gpio
+    pin: GPIO15
+    inverted: true
+    id: yellow_led
+
+
+display:
+  platform: tm1621
+  id: tm1621_display
+  update_interval: 5s
+  cs_pin: GPIO17
+  data_pin: GPIO5
+  read_pin: GPIO23
+  write_pin: GPIO18
+  lambda: |-
+    static int n = 0;
+    id(red_led).turn_on();                                //Keep POWER-led ON
+
+    if (id(gpio_relay).state) id(green_led).turn_on();    //Green LED ON if defrost_prevention_Relay is ON
+    else id(green_led).turn_off();
+
+    if (n == 0) {
+       n = 1;
+       it.printf(0, "%.1f", id(heat_exchanger_temp).state);
+       it.display_celsius(true);
+       it.printf(1, "%.1f", id(outdoor_temp).state);
+       it.display_humidity(false);
+       }
+     else {
+       n = 0;
+       it.printf(0, "%.1f", id(wifi_signal_dbm).state);
+       it.display_celsius(false);
+       it.printf(1,"%.1i", id(outdoor_temp_errors)+ id(heat_exchanger_temp_errors));
+       it.display_humidity(false);
+       }
+
+


### PR DESCRIPTION
Add option to set Dallas sensors as a hub. This can reduce number of unwanted resets.